### PR TITLE
Update for new login flow

### DIFF
--- a/custom_components/telenet_telemeter/__init__.py
+++ b/custom_components/telenet_telemeter/__init__.py
@@ -45,7 +45,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
     """Set up this component using YAML."""
     _LOGGER.info(STARTUP)
     if config.get(DOMAIN) is None:
-        # We get her if the integration is set up using config flow
+        # We get here if the integration is set up using config flow
         return True
 
     try:

--- a/custom_components/telenet_telemeter/sensor.py
+++ b/custom_components/telenet_telemeter/sensor.py
@@ -28,7 +28,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=240)
+PARALLEL_UPDATES = 1
 
 async def dry_setup(hass, config_entry, async_add_devices):
     config = config_entry
@@ -52,10 +53,10 @@ async def dry_setup(hass, config_entry, async_add_devices):
         await data_internet._forced_update()
         assert data_internet._telemeter is not None
         sensor = SensorInternet(data_internet, hass)
-        sensor.async_update()
+        await sensor.async_update()
         sensors.append(sensor)
         binarysensor = SensorPeak(data_internet, hass)
-        binarysensor.async_update()
+        await binarysensor.async_update()
         sensors.append(binarysensor)
     if mobile:
         data_mobile = ComponentData(
@@ -500,8 +501,8 @@ class SensorInternet(Entity):
             "upload_speed": self._upload_speed,
             "modemMac": self._modemMac,
             "wifiEnabled": self._wifiEnabled,
-            "wifreeEnabled": self._wifreeEnabled,
-            "telemeter_json": self._data._telemeter
+            "wifreeEnabled": self._wifreeEnabled
+            # "telemeter_json": self._data._telemeter
         }
 
 

--- a/custom_components/telenet_telemeter/switch.py
+++ b/custom_components/telenet_telemeter/switch.py
@@ -10,7 +10,8 @@ from .utils import *
 
 _LOGGER = logging.getLogger(__name__)
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=240)
+PARALLEL_UPDATES = 1
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Old way."""


### PR DESCRIPTION
These changes should fix #53 #54 and #55

There is however a big caveat, the implementation is not thread-safe, meaning that on startup you will very likely get 401 errors during the flow (my guess is that you can have only one active challenge at a time).

I am however not knowledgeable enough to fix this in the code and it might even require a bunch of rewrites.

I also noticed that peak and offpeak usage are missing, it may be that Telenet is no longer providing these.

//edit: I also updated the update rate to a couple of hours. Hopefully this should prevent Telenet from going after this plugin.