### PR TITLE
Fix bundle product check in get_desired_internet_product

### DIFF
--- a/custom_components/telenet_telemeter/sensor.py
+++ b/custom_components/telenet_telemeter/sensor.py
@@ -137,7 +137,7 @@ def get_desired_internet_product(products, desired_product_type):
     # Try to find a product with productType = "bundle"
     _LOGGER.debug(f'products: {products}, {desired_product_type}')
     bundle_product = next((product for product in products if product.get('productType','').lower() == desired_product_type), None)
-    if desired_product_type == 'bundle' and not bundle_product.get('products'):
+    if desired_product_type == 'bundle' and bundle_product and not bundle_product.get('products'):
         bundle_product = None
     _LOGGER.debug(f'desired_product: {bundle_product}, {desired_product_type}')
     


### PR DESCRIPTION
Check if the bundle product has associated products before returning it.

Fixes #62 