### PR TITLE
Add BASE provider support alongside Telenet

### DIFF
--- a/custom_components/telenet_telemeter/__init__.py
+++ b/custom_components/telenet_telemeter/__init__.py
@@ -102,11 +102,8 @@ def register_services(hass, config_entry):
         password = config.get("password")
         provider = config.get("provider", PROVIDER_TELENET)
         session = TelenetSession(provider=provider)
-        if not(session):
-            session = TelenetSession(provider=provider)
 
-        if session:
-            await hass.async_add_executor_job(lambda: session.login(username, password))
+        await hass.async_add_executor_job(lambda: session.login(username, password))
         provider_name = PROVIDER_NAMES.get(provider, NAME)
         _LOGGER.debug(f"{provider_name} reboot_internet login completed")
         v2 = await hass.async_add_executor_job(lambda: session.apiVersion2())

--- a/custom_components/telenet_telemeter/__init__.py
+++ b/custom_components/telenet_telemeter/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.core import HomeAssistant
 from homeassistant.const import Platform
 from .utils import TelenetSession
+from .const import PROVIDER_TELENET, PROVIDER_NAMES
 from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
@@ -39,14 +40,13 @@ If you have any issues with this you need to open an issue here:
 )
 
 
-_LOGGER = logging.getLogger(DOMAIN)
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType):
     """Set up this component using YAML."""
     _LOGGER.info(STARTUP)
     if config.get(DOMAIN) is None:
-        # We get here if the integration is set up using config flow
         return True
 
     try:
@@ -71,9 +71,6 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     unload_ok = await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
-    # if unload_ok:
-        # hass.data[DOMAIN].pop(config_entry.entry_id)
-
     return unload_ok
 
 
@@ -100,17 +97,18 @@ def register_services(hass, config_entry):
         
     async def handle_reboot_internet(call):
         """Handle the service call."""
-        
         config = config_entry.data
         username = config.get("username")
         password = config.get("password")
-        session = TelenetSession()
+        provider = config.get("provider", PROVIDER_TELENET)
+        session = TelenetSession(provider=provider)
         if not(session):
-            session = TelenetSession()
+            session = TelenetSession(provider=provider)
 
         if session:
             await hass.async_add_executor_job(lambda: session.login(username, password))
-        _LOGGER.debug(f"{NAME} reboot_internet login completed")
+        provider_name = PROVIDER_NAMES.get(provider, NAME)
+        _LOGGER.debug(f"{provider_name} reboot_internet login completed")
         v2 = await hass.async_add_executor_job(lambda: session.apiVersion2())
         if not v2:
             return

--- a/custom_components/telenet_telemeter/config_flow.py
+++ b/custom_components/telenet_telemeter/config_flow.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.const import (
     CONF_NAME,
@@ -69,29 +68,26 @@ class Mixin:
             self._errors["base"] = "no_valid_settings"
             return False
 
-        username = None
         if user_input.get("username"):
             username = user_input.get(CONF_USERNAME)
         else:
             self._errors["base"] = "missing username"
 
-        password = None
         if user_input.get("password"):
             password = user_input.get(CONF_PASSWORD)
         else:
             self._errors["base"] = "missing password"
 
-        internet = None
-        if user_input.get("internet"):
-            internet = user_input.get("internet")
-        else:
+        # Use explicit None check so False (unchecked) is valid
+        internet = user_input.get("internet")
+        if internet is None:
             self._errors["base"] = "missing internet"
 
-        mobile = None
-        if user_input.get("mobile"):
-            mobile = user_input.get("mobile")
-        else:
+        mobile = user_input.get("mobile")
+        if mobile is None:
             self._errors["base"] = "missing mobile"
+
+        return len(self._errors) == 0
 
 
 class ComponentFlowHandler(Mixin, config_entries.ConfigFlow, domain=DOMAIN):
@@ -109,6 +105,8 @@ class ComponentFlowHandler(Mixin, config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             await self.test_setup(user_input)
+            if self._errors:
+                return await self._show_config_form(user_input)
             provider = user_input.get("provider", PROVIDER_TELENET)
             return self.async_create_entry(title=f'{NAME} {provider} {user_input.get("username","")}', data=user_input)
 
@@ -135,7 +133,6 @@ class ComponentOptionsHandler(config_entries.OptionsFlow, Mixin):
         self._errors = {}
 
     async def async_step_init(self, user_input=None):
-
         return self.async_show_form(
             step_id="edit",
             data_schema=vol.Schema(create_schema(self.config_entry, option=True)),
@@ -144,7 +141,7 @@ class ComponentOptionsHandler(config_entries.OptionsFlow, Mixin):
 
     async def async_step_edit(self, user_input):
         if user_input is not None:
-            await self.test_setup(user_input)
+            ok = await self.test_setup(user_input)
             if ok:
                 self.hass.config_entries.async_update_entry(
                     self.config_entry, data=user_input

--- a/custom_components/telenet_telemeter/config_flow.py
+++ b/custom_components/telenet_telemeter/config_flow.py
@@ -16,8 +16,9 @@ from homeassistant.const import (
 
 from . import DOMAIN, NAME
 from .utils import (check_settings)
+from .const import PROVIDERS, PROVIDER_TELENET
 
-_LOGGER = logging.getLogger(DOMAIN)
+_LOGGER = logging.getLogger(__name__)
 
 
 def create_schema(entry, option=False):
@@ -26,18 +27,22 @@ def create_schema(entry, option=False):
     """
 
     if option:
-        # We use .get here incase some of the texts gets changed.
         default_username = entry.data.get(CONF_USERNAME, "")
         default_password = entry.data.get(CONF_PASSWORD, "")
         default_internet = entry.data.get("internet", True)
         default_mobile = entry.data.get("mobile", True)
+        default_provider = entry.data.get("provider", PROVIDER_TELENET)
     else:
         default_username = ""
         default_password = ""
         default_internet = True
         default_mobile = True
+        default_provider = PROVIDER_TELENET
 
     data_schema = OrderedDict()
+    data_schema[
+        vol.Required("provider", default=default_provider, description="Provider")
+    ] = vol.In(PROVIDERS)
     data_schema[
         vol.Required(CONF_USERNAME, description="Email")
     ] = str
@@ -64,31 +69,25 @@ class Mixin:
             self._errors["base"] = "no_valid_settings"
             return False
 
-        # This is what we really need.
         username = None
-
         if user_input.get("username"):
             username = user_input.get(CONF_USERNAME)
         else:
             self._errors["base"] = "missing username"
-            
-            
-        password = None
 
+        password = None
         if user_input.get("password"):
             password = user_input.get(CONF_PASSWORD)
         else:
             self._errors["base"] = "missing password"
-            
-        internet = None
 
+        internet = None
         if user_input.get("internet"):
             internet = user_input.get("internet")
         else:
             self._errors["base"] = "missing internet"
-            
-        mobile = None
 
+        mobile = None
         if user_input.get("mobile"):
             mobile = user_input.get("mobile")
         else:
@@ -105,12 +104,13 @@ class ComponentFlowHandler(Mixin, config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize."""
         self._errors = {}
 
-    async def async_step_user(self, user_input=None):  # pylint: disable=dangerous-default-value
+    async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
 
         if user_input is not None:
             await self.test_setup(user_input)
-            return self.async_create_entry(title=f'{NAME} {user_input.get("username","")}', data=user_input)
+            provider = user_input.get("provider", PROVIDER_TELENET)
+            return self.async_create_entry(title=f'{NAME} {provider} {user_input.get("username","")}', data=user_input)
 
         return await self._show_config_form(user_input)
 
@@ -121,23 +121,13 @@ class ComponentFlowHandler(Mixin, config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=vol.Schema(data_schema), errors=self._errors
         )
 
-    async def async_step_import(self, user_input):  # pylint: disable=unused-argument
-        """Import a config entry.
-        Special type of import, we're not actually going to store any data.
-        Instead, we're going to rely on the values that are in config file.
-        """
+    async def async_step_import(self, user_input):
+        """Import a config entry."""
         return self.async_create_entry(title="configuration.yaml", data={})
-
-    # @staticmethod
-    # @callback
-    # def async_get_options_flow(config_entry):  # TODO
-    #     """Get the options flow for this handler."""
-    #     return ComponentOptionsHandler(config_entry)
 
 
 class ComponentOptionsHandler(config_entries.OptionsFlow, Mixin):
-    """Now this class isnt like any normal option handlers.. as ha devs option seems think options is
-    #  supposed to be EXTRA options, i disagree, a user should be able to edit anything.."""
+    """Options flow handler."""
 
     def __init__(self, config_entry):
         self.config_entry = config_entry
@@ -153,7 +143,6 @@ class ComponentOptionsHandler(config_entries.OptionsFlow, Mixin):
         )
 
     async def async_step_edit(self, user_input):
-        # edit does not work.
         if user_input is not None:
             await self.test_setup(user_input)
             if ok:
@@ -163,7 +152,6 @@ class ComponentOptionsHandler(config_entries.OptionsFlow, Mixin):
                 return self.async_create_entry(title="", data={})
             else:
                 self._errors["base"] = "missing data options handler"
-                # not suere this should be config_entry or user_input.
                 return self.async_show_form(
                     step_id="edit",
                     data_schema=vol.Schema(

--- a/custom_components/telenet_telemeter/const.py
+++ b/custom_components/telenet_telemeter/const.py
@@ -1,1 +1,34 @@
 DOMAIN = "telenet_telemeter"
+NAME = "Telenet Telemeter"
+
+PROVIDER_TELENET = "Telenet"
+PROVIDER_BASE = "BASE"
+PROVIDERS = [PROVIDER_TELENET, PROVIDER_BASE]
+
+PROVIDER_NAMES = {
+    PROVIDER_TELENET: "Telenet Telemeter",
+    PROVIDER_BASE: "BASE Telemeter",
+}
+
+PROVIDER_CONFIG = {
+    PROVIDER_TELENET: {
+        "api_url":          "https://api.prd.telenet.be",
+        "secure_url":       "https://secure.telenet.be",
+        "login_callback":   "telenet_be",
+        "authorization_url":"https://api.prd.telenet.be/ocapi/login/authorization/telenet_be?lang=nl&style_hint=care&targetUrl=https://www2.telenet.be/residential/nl/mytelenet/",
+        "origin":           "https://www2.telenet.be",
+        "referrer":         "https://www2.telenet.be",
+        "alt_referer":      "https://www2.telenet.be/residential/nl/mijn-telenet/",
+        "maintenance_url":  "https://api.prd.telenet.be/omapi/public/publicconfigs/maintenance_ocapi",
+    },
+    PROVIDER_BASE: {
+        "api_url":          "https://api.prd.base.be",
+        "secure_url":       "https://secure.base.be",
+        "login_callback":   "base_be",
+        "authorization_url":"https://api.prd.base.be/ocapi/login/authorization/base_be?lang=nl&style_hint=care&targetUrl=https://www.base.be/",
+        "origin":           "https://www.base.be",
+        "referrer":         "https://www.base.be",
+        "alt_referer":      "https://www.base.be/",
+        "maintenance_url":  "https://api.prd.base.be/omapi/public/publicconfigs/maintenance_ocapi",
+    },
+}

--- a/custom_components/telenet_telemeter/sensor.py
+++ b/custom_components/telenet_telemeter/sensor.py
@@ -734,7 +734,7 @@ class ComponentMobileShared(Entity):
         
     @property
     def unique_id(self) -> str:
-        return f"{NAME} mobile shared"
+        return f"{NAME} mobile shared {self._productid}"
 
     @property
     def name(self) -> str:
@@ -1149,7 +1149,7 @@ class SensorMobile(Entity):
             # Fallback voor monetaire databundels (bv. BASE 15 BoY waarbij €1 = 1 GB)
             # Als data 0 of leeg is maar monetary wel gevuld, gebruik monetary als GB-equivalent
             if (not self._used_percentage_data or self._used_percentage_data == 0) and \
-               not self._total_volume_data or self._total_volume_data == '0 MB':
+               (not self._total_volume_data or self._total_volume_data == '0 MB'):
                 monetary = mobileusage.get('total', {}).get('monetary', {})
                 if monetary and float(monetary.get('startUnits', '0').replace(',', '.')) > 0:
                     total_gb = float(monetary.get('startUnits', '0').replace(',', '.'))

--- a/custom_components/telenet_telemeter/sensor.py
+++ b/custom_components/telenet_telemeter/sensor.py
@@ -13,8 +13,9 @@ from homeassistant.util import Throttle
 
 from . import DOMAIN, NAME
 from .utils import *
+from .const import PROVIDER_TELENET
 
-_LOGGER = logging.getLogger(DOMAIN)
+_LOGGER = logging.getLogger(__name__)
 _TELENET_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.0%z"
 _TELENET_DATETIME_FORMAT_V2 = "%Y-%m-%d"
 _TELENET_DATETIME_FORMAT_MOBILE = "%Y-%m-%dT%H:%M:%S%z"
@@ -37,6 +38,7 @@ async def dry_setup(hass, config_entry, async_add_devices):
     password = config.get("password")
     internet = config.get("internet")
     mobile = config.get("mobile")
+    provider = config.get("provider", PROVIDER_TELENET)
 
     check_settings(config, hass)
     sensors = []
@@ -48,7 +50,8 @@ async def dry_setup(hass, config_entry, async_add_devices):
             internet,
             False,
             async_get_clientsession(hass),
-            hass
+            hass,
+            provider
         )
         await data_internet._forced_update()
         assert data_internet._telemeter is not None
@@ -65,37 +68,31 @@ async def dry_setup(hass, config_entry, async_add_devices):
             False,
             mobile,
             async_get_clientsession(hass),
-            hass
+            hass,
+            provider
         )
         await data_mobile._forced_update()
         assert data_mobile._mobilemeter is not None
-        # createa mobile sensor for each mobile subscription
-        # for mobilenr in data_mobile._mobilemeter
         if not data_mobile._v2:
             mobileusage = data_mobile._mobilemeter.get('mobileusage')
             for idxproduct, product in enumerate(mobileusage):
                 _LOGGER.debug("enumarate mobileusage elements idx:" + str(idxproduct) + ", product: "+ str(product) + " " +  NAME)
-                #shared sensor
                 if product.get('sharedusage'):
                     _LOGGER.info("shared mobileusage element " +  NAME)
                     sensor = ComponentMobileShared(data_mobile, idxproduct, hass)
                     sensors.append(sensor)
-                #unassigned sensor
                 if product.get('unassigned'):
                     _LOGGER.info("unassigned mobileusage element " +  NAME)
                     for idxunsubs, subscription in enumerate(product.get('unassigned').get('mobilesubscriptions')):
                         _LOGGER.debug("enumarate unassigned subsc elements idx:" + str(idxunsubs) + ", subscription: "+ str(subscription) + " " +  NAME)
-                        #unassigned sensor
                         sensor = SensorMobileUnassigned(data_mobile, idxproduct, idxunsubs, hass)
                         sensors.append(sensor)
-                #assigned sensor
                 if product.get('profiles'):
                     _LOGGER.info("assigned mobileusage element " +  NAME)
                     for idxunprofile, profile in enumerate(product.get('profiles')):
                         _LOGGER.debug("enumarate assigned profiles elements idx:" + str(idxunprofile) + ", profile: "+ str(profile) + " " +  NAME)
                         for idxunsubs, subscription in enumerate(product.get('profiles')[idxunprofile].get('mobilesubscriptions')):
                             _LOGGER.debug("enumarate assigned subsc elements idx:" + str(idxunsubs) + ", subscription: "+ str(subscription) + " " +  NAME)
-                            #assigned sensor
                             sensor = SensorMobileAssigned(data_mobile, idxproduct, idxunprofile, idxunsubs, hass)
                             sensors.append(sensor)
         else:
@@ -132,16 +129,13 @@ async def async_remove_entry(hass, config_entry):
         pass
 
 
-# Function to get the desired product
 def get_desired_internet_product(products, desired_product_type):
-    # Try to find a product with productType = "bundle"
     _LOGGER.debug(f'products: {products}, {desired_product_type}')
     bundle_product = next((product for product in products if product.get('productType','').lower() == desired_product_type), None)
     if desired_product_type == 'bundle' and bundle_product and not bundle_product.get('products'):
         bundle_product = None
     _LOGGER.debug(f'desired_product: {bundle_product}, {desired_product_type}')
     
-    # If no bundle is found, look for productType = "internet"
     if not bundle_product:
         return next((product for product in products if product.get('productType','').lower() == 'internet'), products[0])
     
@@ -149,13 +143,14 @@ def get_desired_internet_product(products, desired_product_type):
     return bundle_product
 
 class ComponentData:
-    def __init__(self, username, password, internet, mobile, client, hass):
+    def __init__(self, username, password, internet, mobile, client, hass, provider=PROVIDER_TELENET):
         self._username = username
         self._password = password
         self._internet = internet
         self._mobile = mobile
         self._client = client
-        self._session = TelenetSession()
+        self._provider = provider
+        self._session = TelenetSession(provider=provider)
         self._telemeter = None
         self._mobilemeter = None
         self._producturl = None
@@ -163,11 +158,10 @@ class ComponentData:
         self._v2 = None
         self._hass = hass
         
-    # same as update, but without throttle to make sure init is always executed
     async def _forced_update(self):
         _LOGGER.info("Fetching init stuff for " + NAME)
         if not(self._session):
-            self._session = TelenetSession()
+            self._session = TelenetSession(provider=self._provider)
 
         if self._session:
             await self._hass.async_add_executor_job(lambda: self._session.login(self._username, self._password))
@@ -181,7 +175,6 @@ class ComponentData:
                     self._telemeter = await self._hass.async_add_executor_job(lambda: self._session.telemeter())
                     self._telemeter['productIdentifier'] = self._telemeter.get('internetusage')[0].get('businessidentifier')
                 else:
-                    # try new backend structure
                     planInfo = await self._hass.async_add_executor_job(lambda: self._session.planInfo())
                     productIdentifier = ""
                     _LOGGER.debug(f"planInfo: {planInfo}")
@@ -205,19 +198,14 @@ class ComponentData:
                     dailyUsage = await self._hass.async_add_executor_job(lambda: self._session.productDailyUsage("internet", productIdentifier, startDate,endDate))
                     self._telemeter['internetUsage'] = dailyUsage.get('internetUsage')
 
-                    # customerLocationId = None
                     internetProductIdentifier = None
                     modemMac = None
                     wifiEnabled = None
                     wifreeEnabled = None
                     try:
-                        # customerDetails = await self._hass.async_add_executor_job(lambda: self._session.customerdetails())
-                        # customerLocationId = customerDetails.get('customerLocations')[0].get('id')
-                        
                         internetProductDetails = await self._hass.async_add_executor_job(lambda: self._session.productSubscriptions("INTERNET"))
                         _LOGGER.debug(f"internetProductDetails: {internetProductDetails}")
                         
-                        # Get the desired product
                         desired_product = get_desired_internet_product(internetProductDetails, 'internet')
                         internetProductIdentifier = desired_product.get('identifier')
                         _LOGGER.debug(f"internetProductIdentifier: {internetProductIdentifier}")
@@ -231,9 +219,6 @@ class ComponentData:
                     except:
                         _LOGGER.error('Failure in fetching wifi details')
                     self._telemeter['wifidetails'] = {'internetProductIdentifier': internetProductIdentifier, 'modemMac': modemMac, 'wifiEnabled': wifiEnabled, 'wifreeEnabled': wifreeEnabled}
-                    
-                # mock data
-                # self._telemeter = 
 
                 if not self._v2:
                     self._producturl = self._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('specurl') 
@@ -243,8 +228,6 @@ class ComponentData:
                 _LOGGER.debug(f"ComponentData init telemeter data: {self._telemeter}")
                 assert self._producturl is not None
                 self._product_details = await self._hass.async_add_executor_job(lambda: self._session.telemeter_product_details(self._producturl))
-                # mock data
-                # self._product_details = {"product":{"productid":627,"labelkey":"internet.line.fmc.wigo35gb","visible":True,"family":"FMC_RMD","producttype":"PRODUCT","weight":2,"apps":[{"labelkey":"support"}],"services":[{"labelkey":"surf.fixedinternet.wigo","servicetype":"FIXED_INTERNET","experience":{"experiencetype":"SURF","weight":10},"weight":0,"specifications":[{"labelkey":"spec.fixedinternet.wifree","value":"1","visible":False,"weight":7},{"labelkey":"spec.fixedinternet.speed.download","value":"300","unit":"Mbps","visible":True,"weight":1},{"labelkey":"spec.fixedinternet.volume.download.fup","value":"FUP","visible":True,"weight":3},{"labelkey":"spec.fixedinternet.mailbox.volume","value":"5","unit":"GB","visible":True,"weight":5},{"labelkey":"spec.fixedinternet.mailbox.included","value":"10","visible":True,"weight":4},{"labelkey":"spec.fixedinternet.speed.upload","value":"20","unit":"Mbps","visible":True,"weight":2}]}],"characteristics":{"alert_threshold_marker":{"unit":"GB","value":"750"},"detailed_scale":{"unit":"GB","value":"25"},"productsegment":"RMD","service_category":"FUP","productgroup":"FMC","initial_threshold_2":{"unit":"GB","value":"1050"},"initial_threshold_1":{"unit":"GB","value":"225"},"alert_threshold":{"unit":"GB","value":"525"},"service_category_limit":{"unit":"GB","value":"750"}},"localizedcontent":[{"locale":"nl","name":"All-Internet 300","logo":"https://www2.telenet.be/content/dam/www-telenet-be/img/self-service/products/internet-line-fmc-wigo35gb.png"},{"locale":"fr","name":"All-Internet 300","logo":"https://www2.telenet.be/content/dam/www-telenet-be/img/self-service/products/internet-line-fmc-wigo35gb.png"},{"locale":"en","name":"All-Internet 300","logo":"https://www2.telenet.be/content/dam/www-telenet-be/img/self-service/products/internet-line-fmc-wigo35gb.png"}]}}
                 assert self._product_details is not None
                 _LOGGER.debug(f"ComponentData init telemeter productdetails: {self._product_details}")
             if self._mobile:
@@ -254,7 +237,6 @@ class ComponentData:
                     self._mobilemeter = await self._hass.async_add_executor_job(lambda: self._session.productSubscriptions("MOBILE"))
                 assert self._mobilemeter is not None
                 _LOGGER.debug(f"ComponentData init mobilemeter data: {self._mobilemeter}")
-                
 
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
@@ -317,9 +299,7 @@ class SensorInternet(Entity):
             self._product = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('producttype') 
             self._period_start_date = datetime.strptime(self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('periodstart'), _TELENET_DATETIME_FORMAT)
             self._period_end_date = datetime.strptime(self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('periodend'), _TELENET_DATETIME_FORMAT)
-            # Add one day to the datetime object
             self._period_end_date = self._period_end_date + timedelta(days=1)
-
             tz_info = self._period_end_date.tzinfo
             self._extended_volume = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('extendedvolume').get('volume')
         else:
@@ -327,11 +307,9 @@ class SensorInternet(Entity):
             self._product =  self._data._product_details.get('product').get('labelkey','N/A')
             self._period_start_date =   datetime.strptime(self._data._telemeter.get('startDate'), _TELENET_DATETIME_FORMAT_V2)
             self._period_end_date =  datetime.strptime(self._data._telemeter.get('endDate'), _TELENET_DATETIME_FORMAT_V2)
-
-            # Add one day to the datetime object
             self._period_end_date = self._period_end_date + timedelta(days=1)
             tz_info = self._period_end_date.tzinfo
-            self._extended_volume =  0 #TODO unclear if available
+            self._extended_volume =  0
             wifiDetails = self._data._telemeter.get('wifidetails')
             self._modemMac = wifiDetails.get('modemMac')
             self._wifiEnabled = wifiDetails.get('wifiEnabled')
@@ -345,14 +323,10 @@ class SensorInternet(Entity):
         self._period_length = (self._period_end_date - self._period_start_date).total_seconds()
         seconds_completed = (datetime.now(tz_info) - self._period_start_date).total_seconds()
         self._period_left = round(((self._period_end_date - datetime.now(tz_info)).total_seconds())/86400,2)
-        # self._period_used = self._period_length - self._period_left
         self._period_used = seconds_completed
         _LOGGER.debug(f"SensorInternet end date: {self._period_end_date} - now {datetime.now(tz_info)} = perdiod_left {self._period_left}, self._period_length {self._period_length}")
         self._period_used_percentage = round(100 * (self._period_used / self._period_length),1)
-        
-        
-        
-        # _LOGGER.debug(f"SensorInternet specifications: {self._data._product_details.get('product').get('services')[0].get('specifications')}")
+
         for servicetype in self._data._product_details.get('product').get('services'):
             if servicetype.get('servicetype') == 'FIXED_INTERNET':
                 for productdetails in servicetype.get('specifications'):
@@ -363,8 +337,6 @@ class SensorInternet(Entity):
                         self._upload_speed = f"{productdetails.get('value')} {productdetails.get('unit')}"
                 break
         
-        #original way to get included volume, but now getting out of product details to get FUP limits
-        # self._included_volume = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('includedvolume')
         if type(self._data._product_details.get('product').get('characteristics').get('service_category_limit')) == dict:
             self._included_volume = int((self._data._product_details.get('product').get('characteristics').get('service_category_limit').get('value'))) * 1024 * 1024
         elif type(self._data._product_details.get('product').get('characteristics').get('elementarycharacteristics')) == list:
@@ -373,7 +345,6 @@ class SensorInternet(Entity):
                     self._included_volume = int(elem.get('value')) * 1024 * 1024
                     break
         else:
-            #Max volume not found in product details, so retrieve value out of telemeter
             if not self._data._v2:
                 self._included_volume = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('includedvolume')
             else:
@@ -381,15 +352,11 @@ class SensorInternet(Entity):
         self._total_volume = (self._included_volume + self._extended_volume) / 1024 / 1024
         
         if (not self._data._v2 and self._data._telemeter and self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('peak') is None) or (self._data._v2 and self._data._telemeter and self._data._telemeter.get('internet').get('category') == 'CAP'):
-            #https://www2.telenet.be/content/www-telenet-be/nl/klantenservice/wat-is-de-telemeter
-            #CAPPED subscription (not unlimited)
             if not self._data._v2:
-                # self._wifree_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('wifree')
                 self._wifree_usage = 0
                 self._includedvolume_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('includedvolume')
                 self._extendedvolume_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('extendedvolume')
             else:
-                # self._wifree_usage = self._data._telemeter.get('internet').get('wifreeUsage').get('usedUnits')
                 self._wifree_usage = 0
                 self._includedvolume_usage = self._data._telemeter.get('internet').get('totalUsage').get('units', 0)
                 self._extendedvolume_usage = self._data._telemeter.get('internet').get('extendedUsage').get('volume', 0)
@@ -404,7 +371,6 @@ class SensorInternet(Entity):
                 if self._data._v2: 
                     if self._data._telemeter.get('internet').get('usedPercentage') != None:
                         self._used_percentage = float(self._data._telemeter.get('internet').get('usedPercentage',0))
-                
             
             if self._used_percentage >= 100:
                 self._squeezed = True
@@ -412,22 +378,18 @@ class SensorInternet(Entity):
                 self._squeezed = False
             
         else:
-            #Unlimited FUP subscription, not capped
-            #when peak indication is available, only use peak + wifree in total used counter, as offpeak is not attributed
             if not self._data._v2:
-                # self._wifree_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('wifree')
                 self._wifree_usage = 0
                 self._peak_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('peak')
                 self._offpeak_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('offpeak')
                 self._squeezed = bool(self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('squeezed'))
                 self._extendedvolume_usage = 0
             else:
-                # self._wifree_usage = self._data._telemeter.get('internet').get('wifreeUsage').get('usedUnits')
                 self._wifree_usage = 0
-                self._peak_usage = round(self._data._telemeter.get('internetUsage')[0].get('totalUsage').get('peak',0),1)
+                self._peak_usage = round(self._data._telemeter.get('internetUsage')[0].get('totalUsage').get('peak', 0) or 0, 1)
                 self._includedvolume_usage = self._peak_usage
                 self._extendedvolume_usage = 0
-                self._offpeak_usage = round(self._data._telemeter.get('internetUsage')[0].get('totalUsage').get('offPeak',0),1)
+                self._offpeak_usage = round(self._data._telemeter.get('internetUsage')[0].get('totalUsage').get('offPeak', 0) or 0, 1)
             self._used_percentage = 0
             if ( self._included_volume + self._extended_volume) != 0:
                 if not self._data._v2:
@@ -451,25 +413,18 @@ class SensorInternet(Entity):
             _LOGGER.debug(f"SensorInternet _used_percentage: {self._used_percentage}")
             _LOGGER.debug(f"SensorInternet _squeezed: {self._squeezed}")
             
-
-            
         
     async def async_will_remove_from_hass(self):
         """Clean up after entity before removal."""
         _LOGGER.info("async_will_remove_from_hass " + NAME)
         self._data.clear_session()
 
-
     @property
     def icon(self) -> str:
-        """Shows the correct icon for container."""
         return "mdi:check-network-outline"
-        #alternative: 
-        #return "mdi:wifi_tethering_error"
         
     @property
     def unique_id(self) -> str:
-        """Return the name of the sensor."""
         return (
             f"{NAME} internet {self._data._telemeter.get('productIdentifier')}"
         )
@@ -480,7 +435,6 @@ class SensorInternet(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        """Return the state attributes."""
         return {
             ATTR_ATTRIBUTION: NAME,
             "last update": self._last_update,
@@ -504,13 +458,10 @@ class SensorInternet(Entity):
             "modemMac": self._modemMac,
             "wifiEnabled": self._wifiEnabled,
             "wifreeEnabled": self._wifreeEnabled
-            # "telemeter_json": self._data._telemeter
         }
-
 
     @property
     def device_info(self) -> dict:
-        """Return the device info."""
         return {
             "identifiers": {(NAME, self._data.unique_id)},
             "name": self._data.name,
@@ -519,12 +470,10 @@ class SensorInternet(Entity):
 
     @property
     def unit(self) -> int:
-        """Unit"""
         return int
 
     @property
     def unit_of_measurement(self) -> str:
-        """Return the unit of measurement this sensor expresses itself in."""
         return "%"
 
     @property
@@ -540,24 +489,19 @@ class SensorPeak(BinarySensorEntity):
         self._product = None
         self._peak = None
         self._servicecategory = None
-                
         self._download_speed = None
         self._upload_speed = None
-                
         self._used_percentage = None
         self._peak_usage = None
         self._offpeak_usage = None
         self._wifree_usage = None
-        
         self._included_volume = None
         self._extended_volume = None
         self._total_volume = None
         self._squeezed = False
-        
 
     @property
     def is_on(self):
-        """Return True if the binary sensor is on."""
         return self._peak
 
     async def async_update(self):
@@ -569,11 +513,9 @@ class SensorPeak(BinarySensorEntity):
         else:
             self._last_update =  self._data._telemeter.get('internet').get('totalUsage').get('lastUsageDate')
             self._product =  self._data._product_details.get('product').get('labelkey','N/A')      
-            self._extended_volume =  0 #TODO unclear if available
+            self._extended_volume =  0
         self._servicecategory = self._data._product_details.get('product').get('characteristics').get('service_category')
-        
 
-        # _LOGGER.debug(f"SensorInternet specifications: {self._data._product_details.get('product').get('services')[0].get('specifications')}")
         for servicetype in self._data._product_details.get('product').get('services'):
             if servicetype.get('servicetype') == 'FIXED_INTERNET':
                 for productdetails in servicetype.get('specifications'):
@@ -584,9 +526,6 @@ class SensorPeak(BinarySensorEntity):
                         self._upload_speed = f"{productdetails.get('value')} {productdetails.get('unit')}"
                 break
             
-            
-        #original way to get included volume, but now getting out of product details to get FUP limits
-        # self._included_volume = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('includedvolume')
         if type(self._data._product_details.get('product').get('characteristics').get('service_category_limit')) == dict:
             self._included_volume = int((self._data._product_details.get('product').get('characteristics').get('service_category_limit').get('value'))) * 1024 * 1024
         elif type(self._data._product_details.get('product').get('characteristics').get('elementarycharacteristics')) == list:
@@ -595,27 +534,21 @@ class SensorPeak(BinarySensorEntity):
                     self._included_volume = int(elem.get('value')) * 1024 * 1024
                     break
         else:
-            #Max volume not found in product details, so retrieve value out of telemeter
             if not self._data._v2:
                 self._included_volume = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('includedvolume')
             else:
                 self._included_volume = self._data._telemeter.get('internet').get('allocatedUsage').get('units') * 1024 * 1024
         self._total_volume = (self._included_volume + self._extended_volume) / 1024 / 1024
                 
-                
         if (not self._data._v2 and self._data._telemeter and self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('peak') is None) or (self._data._v2 and self._data._telemeter and self._data._telemeter.get('internet').get('category') == 'CAP'):
-            #https://www2.telenet.be/content/www-telenet-be/nl/klantenservice/wat-is-de-telemeter
             if not self._data._v2:
-                # self._wifree_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('wifree')
                 self._wifree_usage = 0
                 self._includedvolume_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('includedvolume')
                 self._extendedvolume_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('extendedvolume')
             else:
-                # self._wifree_usage = self._data._telemeter.get('internet').get('wifreeUsage').get('usedUnits')
                 self._wifree_usage = 0
                 self._includedvolume_usage = self._data._telemeter.get('internet').get('totalUsage').get('units')
                 self._extendedvolume_usage = self._data._telemeter.get('internet').get('extendedUsage').get('volume')
-            
             
             self._used_percentage = 0
             if ( self._included_volume + self._extended_volume) != 0:
@@ -631,14 +564,9 @@ class SensorPeak(BinarySensorEntity):
                 self._squeezed = True
             else:
                 self._squeezed = False
-            # Get the current time
             now = datetime.now().time()
-
-            # Define the start time and end time for the period
-            start_time = time(10, 0, 0) # 10:00:00 
-            end_time = time(23, 59, 59) # 23:59:59
-
-            # Check if the current time is between the start time and end time
+            start_time = time(10, 0, 0)
+            end_time = time(23, 59, 59)
             if start_time <= now <= end_time:
                 self._peak = True
             else:
@@ -652,25 +580,16 @@ class SensorPeak(BinarySensorEntity):
             _LOGGER.debug(f"SensorPeak _peak: {self._peak}")
             
         else:
-            #when peak indication is available, only use peak + wifree in total used counter, as offpeak is not attributed
-            
-            #https://www2.telenet.be/content/www-telenet-be/nl/klantenservice/wat-is-de-telemeter
-            
-            #peak rules: https://www2.telenet.be/nl/klantenservice/wat-zijn-de-piek-en-daluren-bij-een-abonnement-met-onbeperkt-surfen/
-            # https://www2.telenet.be/nl/klantenservice/wat-is-onbeperkt-surfen/
-            
             if not self._data._v2:
-                # self._wifree_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('wifree')
                 self._wifree_usage = 0
                 self._peak_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('peak')
                 self._offpeak_usage = self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('totalusage').get('offpeak')
                 self._squeezed = bool(self._data._telemeter.get('internetusage')[0].get('availableperiods')[0].get('usages')[0].get('squeezed'))
             else:
-                # self._wifree_usage = self._data._telemeter.get('internet').get('wifreeUsage').get('usedUnits')
                 self._wifree_usage = 0
-                self._peak_usage = round(self._data._telemeter.get('internetUsage')[0].get('totalUsage').get('peak'),1)
+                self._peak_usage = round(self._data._telemeter.get('internetUsage')[0].get('totalUsage').get('peak', 0) or 0, 1)
                 self._includedvolume_usage = self._peak_usage
-                self._offpeak_usage = round(self._data._telemeter.get('internetUsage')[0].get('totalUsage').get('offPeak'),1)
+                self._offpeak_usage = round(self._data._telemeter.get('internetUsage')[0].get('totalUsage').get('offPeak', 0) or 0, 1)
             
             self._used_percentage = 0
             if ( self._included_volume + self._extended_volume) != 0:
@@ -684,44 +603,29 @@ class SensorPeak(BinarySensorEntity):
             else:
                 self._squeezed = False
             
-            # Unclear if speed in product details will be updated based on actual usage 
-            # most subscription will fall back onto 100Mbps/1Mbps, except for ONEup onto 200Mbps/2Mbps
             if self._used_percentage >= 100:
                 self._download_speed = f"10 Mbps"
                 self._upload_speed = f"1 Mbps"
-            
 
-            # Get the current time
             now = datetime.now().time()
-
-            # Define the start time and end time for the period
-            start_time = time(17, 0, 0) # 17u during as action on corona, non-corona: 12:00:00
-            end_time = time(23, 59, 59) # 23:59:59
-
-            # Check if the current time is between the start time and end time
+            start_time = time(17, 0, 0)
+            end_time = time(23, 59, 59)
             if start_time <= now <= end_time:
                 self._peak = True
             else:
                 self._peak = False
             
-            
         
     async def async_will_remove_from_hass(self):
-        """Clean up after entity before removal."""
         _LOGGER.info("async_will_remove_from_hass " + NAME)
         self._data.clear_session()
 
-
     @property
     def icon(self) -> str:
-        """Shows the correct icon for container."""
         return "mdi:check-network-outline"
-        #alternative: 
-        #return "mdi:wifi_tethering_error"
         
     @property
     def unique_id(self) -> str:
-        """Return the name of the sensor."""
         return (
             f"{NAME} peak {self._data._telemeter.get('productIdentifier')}"
         )
@@ -732,7 +636,6 @@ class SensorPeak(BinarySensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        """Return the state attributes."""
         return {
             ATTR_ATTRIBUTION: NAME,
             "last update": self._last_update,
@@ -747,24 +650,18 @@ class SensorPeak(BinarySensorEntity):
             "upload_speed": self._upload_speed
         }
 
-
     @property
     def friendly_name(self) -> str:
         return self.unique_id
-        
 
     @property
     def device_info(self) -> dict:
-        """Return the device info."""
         return {
             "identifiers": {(NAME, self._data.unique_id)},
             "name": self._data.name,
             "manufacturer": NAME,
         }
 
-        
-        
-        
 
 class ComponentMobileShared(Entity):
     def __init__(self, data, productid, hass):
@@ -788,7 +685,6 @@ class ComponentMobileShared(Entity):
 
     @property
     def state(self):
-        """Return the state of the sensor."""
         return self._used_percentage_data
 
     async def async_update(self):
@@ -802,18 +698,11 @@ class ComponentMobileShared(Entity):
             self._last_update =  productdetails.get('lastupdated')
             self._product = productdetails.get('label')
             self._period_end_date = productdetails.get('nextbillingdate')
-            # Parse the timestamp string into a datetime object
             original_datetime = datetime.strptime(self._period_end_date, _TELENET_DATETIME_FORMAT_MOBILE)
-
-            # Add one day to the datetime object
             new_datetime = original_datetime + timedelta(days=1)
-
-            # Format the new datetime object back to a string
             self._period_end_date = new_datetime.strftime(_TELENET_DATETIME_FORMAT_MOBILE)
-            # get shared sensor
             sharedusage = productdetails.get('sharedusage')
             
-            #todo: add checks on empty elements
             if sharedusage:
                 if sharedusage.get('included'):
                     if sharedusage.get('included').get('data'):
@@ -836,24 +725,16 @@ class ComponentMobileShared(Entity):
 
         
     async def async_will_remove_from_hass(self):
-        """Clean up after entity before removal."""
         _LOGGER.info("async_will_remove_from_hass " + NAME)
         self._data.clear_session()
 
-
     @property
     def icon(self) -> str:
-        """Shows the correct icon for container."""
         return "mdi:check-network-outline"
-        #alternative: 
-        #return "mdi:wifi_tethering_error"
         
     @property
     def unique_id(self) -> str:
-        """Return the name of the sensor."""
-        return (
-            f"{NAME} mobile shared"
-        )
+        return f"{NAME} mobile shared"
 
     @property
     def name(self) -> str:
@@ -861,7 +742,6 @@ class ComponentMobileShared(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        """Return the state attributes."""
         return {
             ATTR_ATTRIBUTION: NAME,
             "last update": self._last_update,
@@ -880,10 +760,8 @@ class ComponentMobileShared(Entity):
             "mobile_json": self._data._mobilemeter
         }
 
-
     @property
     def device_info(self) -> dict:
-        """Return the device info."""
         return {
             "identifiers": {(NAME, self._data.unique_id)},
             "name": self._data.name,
@@ -892,12 +770,10 @@ class ComponentMobileShared(Entity):
 
     @property
     def unit(self) -> int:
-        """Unit"""
         return int
 
     @property
     def unit_of_measurement(self) -> str:
-        """Return the unit of measurement this sensor expresses itself in."""
         return "%"
 
     @property
@@ -929,7 +805,6 @@ class SensorMobileUnassigned(Entity):
 
     @property
     def state(self):
-        """Return the state of the sensor."""
         return self._used_percentage_data
 
     async def async_update(self):
@@ -942,18 +817,11 @@ class SensorMobileUnassigned(Entity):
         self._last_update =  productdetails.get('lastupdated')
         self._product = productdetails.get('label')
         self._period_end_date = productdetails.get('nextbillingdate')
-        # Parse the timestamp string into a datetime object
         original_datetime = datetime.strptime(self._period_end_date, _TELENET_DATETIME_FORMAT_MOBILE)
-
-        # Add one day to the datetime object
         new_datetime = original_datetime + timedelta(days=1)
-
-        # Format the new datetime object back to a string
         self._period_end_date = new_datetime.strftime(_TELENET_DATETIME_FORMAT_MOBILE)
-        # get shared sensor
         unassignesub = productdetails.get('unassigned').get('mobilesubscriptions')[self._subsid]
         
-        #todo: add checks on empty elements
         if unassignesub:
             if unassignesub.get('included'):
                 if unassignesub.get('included').get('data'):
@@ -977,24 +845,16 @@ class SensorMobileUnassigned(Entity):
                 self._outofbundle = f"{unassignesub.get('outofbundle').get('usedunits')} {unassignesub.get('outofbundle').get('unittype')}"
             self._mobileinternetonly = unassignesub.get('mobileinternetonly')               
                 
-            
-        
     async def async_will_remove_from_hass(self):
-        """Clean up after entity before removal."""
         _LOGGER.info("async_will_remove_from_hass " + NAME)
         self._data.clear_session()
 
-
     @property
     def icon(self) -> str:
-        """Shows the correct icon for container."""
         return "mdi:check-network-outline"
-        #alternative: 
-        #return "mdi:wifi_tethering_error"
         
     @property
     def unique_id(self) -> str:
-        """Return the name of the sensor."""
         return (
             f"{NAME} mobile {self._data._mobilemeter.get('mobileusage')[self._productid].get('unassigned').get('mobilesubscriptions')[self._subsid].get('mobile')}"
         )
@@ -1005,7 +865,6 @@ class SensorMobileUnassigned(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        """Return the state attributes."""
         return {
             ATTR_ATTRIBUTION: NAME,
             "last update": self._last_update,
@@ -1029,22 +888,18 @@ class SensorMobileUnassigned(Entity):
 
     @property
     def device_info(self) -> dict:
-        """Return the device info."""
         return {
             "identifiers": {(NAME, self._data.unique_id)},
             "name": self._data.name,
             "manufacturer": NAME,
         }
 
-
     @property
     def unit(self) -> int:
-        """Unit"""
         return int
 
     @property
     def unit_of_measurement(self) -> str:
-        """Return the unit of measurement this sensor expresses itself in."""
         return "%"
 
     @property
@@ -1083,7 +938,6 @@ class SensorMobileAssigned(Entity):
 
     @property
     def state(self):
-        """Return the state of the sensor."""
         return self._used_percentage_data
 
     async def async_update(self):
@@ -1096,20 +950,12 @@ class SensorMobileAssigned(Entity):
         self._last_update =  productdetails.get('lastupdated')
         self._product = productdetails.get('label')
         self._period_end_date = productdetails.get('nextbillingdate')
-        # Parse the timestamp string into a datetime object
         original_datetime = datetime.strptime(self._period_end_date, _TELENET_DATETIME_FORMAT_MOBILE)
-
-        # Add one day to the datetime object
         new_datetime = original_datetime + timedelta(days=1)
-
-        # Format the new datetime object back to a string
         self._period_end_date = new_datetime.strftime(_TELENET_DATETIME_FORMAT_MOBILE)
-        # get shared sensor
         profile = productdetails.get('profiles')[self._profileid]
         
-        #todo: add checks on empty elements
         if profile:
-            
             assignesub = profile.get('mobilesubscriptions')[self._subsid]
             if assignesub:
                 if assignesub.get('included'):
@@ -1133,29 +979,20 @@ class SensorMobileAssigned(Entity):
                 if assignesub.get('outofbundle'):
                     self._outofbundle = f"{assignesub.get('outofbundle').get('usedunits')} {assignesub.get('outofbundle').get('unittype')}"
                 self._mobileinternetonly = assignesub.get('mobileinternetonly')    
-
                 self._firstname = profile.get('firstname')
                 self._lastname = profile.get('lastname')
                 self._role = profile.get('role')                
                 
-            
-        
     async def async_will_remove_from_hass(self):
-        """Clean up after entity before removal."""
         _LOGGER.info("async_will_remove_from_hass " + NAME)
         self._data.clear_session()
 
-
     @property
     def icon(self) -> str:
-        """Shows the correct icon for container."""
         return "mdi:check-network-outline"
-        #alternative: 
-        #return "mdi:wifi_tethering_error"
         
     @property
     def unique_id(self) -> str:
-        """Return the name of the sensor."""
         return (
             f"{NAME} mobile {self._data._mobilemeter.get('mobileusage')[self._productid].get('profiles')[self._profileid].get('mobilesubscriptions')[self._subsid].get('mobile')}"
         )
@@ -1166,7 +1003,6 @@ class SensorMobileAssigned(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        """Return the state attributes."""
         return {
             ATTR_ATTRIBUTION: NAME,
             "last update": self._last_update,
@@ -1191,25 +1027,20 @@ class SensorMobileAssigned(Entity):
             "role": self._role
         }
 
-
     @property
     def device_info(self) -> dict:
-        """Return the device info."""
         return {
             "identifiers": {(NAME, self._data.unique_id)},
             "name": self._data.name,
             "manufacturer": NAME,
         }
 
-
     @property
     def unit(self) -> int:
-        """Unit"""
         return int
 
     @property
     def unit_of_measurement(self) -> str:
-        """Return the unit of measurement this sensor expresses itself in."""
         return "%"
 
     @property
@@ -1249,7 +1080,6 @@ class SensorMobile(Entity):
 
     @property
     def state(self):
-        """Return the state of the sensor."""
         return self._state
 
     async def async_update(self):
@@ -1271,13 +1101,8 @@ class SensorMobile(Entity):
         self._last_update =  mobileusage.get('lastUpdated')
         self._label = self._product = self._productSubscription.get('label')
         self._period_end_date = mobileusage.get('nextBillingDate')
-        # Parse the timestamp string into a datetime object
         original_datetime = datetime.strptime(self._period_end_date, _TELENET_DATETIME_FORMAT_MOBILE)
-
-        # Add one day to the datetime object
         new_datetime = original_datetime + timedelta(days=1)
-
-        # Format the new datetime object back to a string
         self._period_end_date = new_datetime.strftime(_TELENET_DATETIME_FORMAT_MOBILE)
         self._outofbundle = f"{mobileusage.get('outOfBundle').get('usedUnits')} {mobileusage.get('outOfBundle').get('unitType')}"
         self._number = self._identifier
@@ -1320,6 +1145,21 @@ class SensorMobile(Entity):
                 if 'remainingUnits' in data:
                     self._remaining_volume_data = f"{data.get('remainingUnits')} {data.get('unitType')}"
                 _LOGGER.debug(f"Mobile {self._identifier}: Data {self._total_volume_data} {self._used_percentage_data} {self._remaining_volume_data}")
+
+            # Fallback voor monetaire databundels (bv. BASE 15 BoY waarbij €1 = 1 GB)
+            # Als data 0 of leeg is maar monetary wel gevuld, gebruik monetary als GB-equivalent
+            if (not self._used_percentage_data or self._used_percentage_data == 0) and \
+               not self._total_volume_data or self._total_volume_data == '0 MB':
+                monetary = mobileusage.get('total', {}).get('monetary', {})
+                if monetary and float(monetary.get('startUnits', '0').replace(',', '.')) > 0:
+                    total_gb = float(monetary.get('startUnits', '0').replace(',', '.'))
+                    remaining_gb = float(monetary.get('remainingUnits', '0').replace(',', '.'))
+                    used_gb = float(monetary.get('usedUnits', '0').replace(',', '.'))
+                    used_pct = monetary.get('usedPercentage', 0)
+                    self._total_volume_data = f"{total_gb:.2f} GB"
+                    self._remaining_volume_data = f"{remaining_gb:.2f} GB"
+                    self._used_percentage_data = used_pct
+                    _LOGGER.debug(f"Mobile {self._identifier}: Monetary fallback - Data {self._total_volume_data} {self._used_percentage_data}% {self._remaining_volume_data}")
                 
             if 'text' in usage:
                 if shared:
@@ -1361,21 +1201,15 @@ class SensorMobile(Entity):
                     self._state = self._used_percentage_voice
         
     async def async_will_remove_from_hass(self):
-        """Clean up after entity before removal."""
         _LOGGER.info("async_will_remove_from_hass " + NAME)
         self._data.clear_session()
 
-
     @property
     def icon(self) -> str:
-        """Shows the correct icon for container."""
         return "mdi:cellphone-information"
-        #alternative: 
-        #return "mdi:wifi_tethering_error"
         
     @property
     def unique_id(self) -> str:
-        """Return the name of the sensor."""
         return (
             f"{NAME} mobile {self._productSubscription.get('identifier')}"
         )
@@ -1386,7 +1220,6 @@ class SensorMobile(Entity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        """Return the state attributes."""
         return {
             ATTR_ATTRIBUTION: NAME,
             "label": self._label,
@@ -1416,7 +1249,6 @@ class SensorMobile(Entity):
 
     @property
     def device_info(self) -> dict:
-        """Return the device info."""
         return {
             "identifiers": {(NAME, self._data.unique_id)},
             "name": self._data.name,
@@ -1425,12 +1257,10 @@ class SensorMobile(Entity):
 
     @property
     def unit(self) -> int:
-        """Unit"""
         return int
 
     @property
     def unit_of_measurement(self) -> str:
-        """Return the unit of measurement this sensor expresses itself in."""
         return "%"
 
     @property

--- a/custom_components/telenet_telemeter/switch.py
+++ b/custom_components/telenet_telemeter/switch.py
@@ -7,7 +7,7 @@ from homeassistant.const import CONF_USERNAME
 from homeassistant.util import Throttle
 
 from . import DOMAIN, NAME
-from .utils import *
+from .utils import TelenetSession, check_settings
 from .const import PROVIDER_TELENET
 
 _LOGGER = logging.getLogger(__name__)
@@ -64,8 +64,6 @@ class ComponentSwitch():
 
 
     async def handle_switch_wireless(self, enableWifi):
-        if not(self._session):
-            self._session = TelenetSession(provider=self._provider)
         await self._hass.async_add_executor_job(lambda: self._session.login(self._username, self._password))
         v2 = await self._hass.async_add_executor_job(lambda: self._session.apiVersion2())
         if not v2:
@@ -98,9 +96,7 @@ class ComponentSwitch():
             enableWifi = wifiEnabled
 
         _LOGGER.debug(f"wifi change required: wifiEnabled: {wifiEnabled}, enableWifi: {enableWifi}")
-
         await self._hass.async_add_executor_job(lambda: self._session.switchWifi(enableWifi, internetProductIdentifier, modemMac, customerLocationId))
-
         _LOGGER.debug(f"{NAME} handle_switch_wifi switch executed, old state: wifiEnabled: {wifiEnabled}, new state: enableWifi: {enableWifi}")
         
         wifiDetails = await self._hass.async_add_executor_job(lambda: self._session.wifidetails(internetProductIdentifier, modemMac))
@@ -117,8 +113,6 @@ class ComponentSwitch():
         return self.unique_id
     
     async def force_update(self):
-        if not(self._session):
-            self._session = TelenetSession(provider=self._provider)
         await self._hass.async_add_executor_job(lambda: self._session.login(self._username, self._password))
         v2 = await self._hass.async_add_executor_job(lambda: self._session.apiVersion2())
         if not v2:

--- a/custom_components/telenet_telemeter/switch.py
+++ b/custom_components/telenet_telemeter/switch.py
@@ -8,8 +8,9 @@ from homeassistant.util import Throttle
 
 from . import DOMAIN, NAME
 from .utils import *
+from .const import PROVIDER_TELENET
 
-_LOGGER = logging.getLogger(DOMAIN)
+_LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=240)
 PARALLEL_UPDATES = 1
@@ -29,8 +30,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     assert data._identifier is not None
     wifiSwitch = WifiSwitch(data)
     switches.append(wifiSwitch)
-    # wifreeSwitch = WifreeSwitch(data)
-    # switches.append(wifreeSwitch)
 
     async_add_entities(switches)
 
@@ -43,43 +42,34 @@ async def async_remove_entry(hass, config_entry):
         pass
 
 
-
-# Function to get the desired product
 def get_desired_internet_product(products, desired_product_type):
-    # Try to find a product with productType = "bundle"
     bundle_product = next((product for product in products if product.get('productType').lower() == desired_product_type), None)
     _LOGGER.debug(f'desired_product: {bundle_product}, {desired_product_type}')
     
-    # If no bundle is found, look for productType = "internet"
     if not bundle_product:
         return next((product for product in products if product.get('productType').lower() == 'internet'), products[0])
     
     return bundle_product      
 
 class ComponentSwitch():
-    """Representation of a Audi switch."""
     def __init__(self, hass, config):
         self._hass = hass
         self._username = config.get('username')
         self._password = config.get('password')
+        self._provider = config.get('provider', PROVIDER_TELENET)
         self._wifiState = None
-        self._session = TelenetSession()
+        self._session = TelenetSession(provider=self._provider)
         self._update_required = True
         self._identifier = None
 
 
     async def handle_switch_wireless(self, enableWifi):
-        """Handle the service call."""
-        
         if not(self._session):
-            self._session = TelenetSession()
+            self._session = TelenetSession(provider=self._provider)
         await self._hass.async_add_executor_job(lambda: self._session.login(self._username, self._password))
         v2 = await self._hass.async_add_executor_job(lambda: self._session.apiVersion2())
         if not v2:
             return
-        
-        # customerDetails = await hass.async_add_executor_job(lambda: session.customerdetails())
-        # customerLocationId = customerDetails.get('customerLocations')[0].get('id')
         
         internetProductDetails = await self._hass.async_add_executor_job(lambda: self._session.productSubscriptions("INTERNET"))
         bundle = get_desired_internet_product(internetProductDetails, "internet")
@@ -100,31 +90,20 @@ class ComponentSwitch():
             if option.get('specurl'):
                 urlDetails = await self._hass.async_add_executor_job(lambda: self._session.urldetails(option.get('specurl')))
 
-        # wifiDetails = await self._hass.async_add_executor_job(lambda: self._session.wifidetails(internetProductIdentifier, modemMac))
-        # wifiEnabled = wifiDetails.get('wirelessEnabled')
-        # wifiEnabled = wifiDetails.get("wirelessInterfaces")[0].get('active')
         wifiStatus = await self._hass.async_add_executor_job(lambda: self._session.wifiStatus(internetProductIdentifier, modemMac))
         _LOGGER.debug(f"wifiStatus switch handle: {wifiStatus}")
         wifiEnabled = wifiStatus.get('cos') == 'WSO_SHARING'
-        # _LOGGER.debug(f"wifidetails switch handle: {wifiDetails}")
 
         if enableWifi is None:
             enableWifi = wifiEnabled
 
-        # if wifiEnabled and enableWifi and wifreeEnabled == enableWifree:
-        #     _LOGGER.debug(f"no wifi change required: wifiEnabled: {wifiEnabled}, enableWifi: {enableWifi}, wifreeEnabled: {wifreeEnabled}, enableWifree: {enableWifree}")
-        #     return
-        # else:
         _LOGGER.debug(f"wifi change required: wifiEnabled: {wifiEnabled}, enableWifi: {enableWifi}")
 
-    
         await self._hass.async_add_executor_job(lambda: self._session.switchWifi(enableWifi, internetProductIdentifier, modemMac, customerLocationId))
 
         _LOGGER.debug(f"{NAME} handle_switch_wifi switch executed, old state: wifiEnabled: {wifiEnabled}, new state: enableWifi: {enableWifi}")
         
-        
         wifiDetails = await self._hass.async_add_executor_job(lambda: self._session.wifidetails(internetProductIdentifier, modemMac))
-        # wifiEnabled = wifiDetails.get('wirelessEnabled')
         self._wifiState = enableWifi
         self._update_required = True
         return
@@ -132,23 +111,18 @@ class ComponentSwitch():
     @property
     def unique_id(self):
         return f"{NAME} {self._username}"
+
     @property
     def name(self) -> str:
-        """Return the name of the sensor."""
         return self.unique_id
     
     async def force_update(self):
-        """Handle the service call."""
-        
         if not(self._session):
-            self._session = TelenetSession()
+            self._session = TelenetSession(provider=self._provider)
         await self._hass.async_add_executor_job(lambda: self._session.login(self._username, self._password))
         v2 = await self._hass.async_add_executor_job(lambda: self._session.apiVersion2())
         if not v2:
             return
-        
-        # customerDetails = await hass.async_add_executor_job(lambda: session.customerdetails())
-        # customerLocationId = customerDetails.get('customerLocations')[0].get('id')
         
         internetProductDetails = await self._hass.async_add_executor_job(lambda: self._session.productSubscriptions("INTERNET"))
         bundle = get_desired_internet_product(internetProductDetails, "internet")
@@ -159,19 +133,7 @@ class ComponentSwitch():
         modemMac = modemDetails.get('mac')
 
         productServiceDetails = await self._hass.async_add_executor_job(lambda: self._session.productService(internetProductIdentifier, "INTERNET"))
-        # customerLocationId = productServiceDetails.get('locationId')
         
-        # for lineLevelProduct in productServiceDetails.get('lineLevelProducts',[]):
-        #     if lineLevelProduct.get('specurl'):
-        #         urlDetails = await self._hass.async_add_executor_job(lambda: self._session.urldetails(lineLevelProduct.get('specurl')))
-
-        # for option in productServiceDetails.get('options',[]):
-        #     if option.get('specurl'):
-        #         urlDetails = await self._hass.async_add_executor_job(lambda: self._session.urldetails(option.get('specurl')))
-        
-        # wifiDetails = await self._hass.async_add_executor_job(lambda: self._session.wifidetails(internetProductIdentifier, modemMac))
-        # wifiEnabled = wifiDetails.get('wirelessEnabled')
-        # _LOGGER.debug(f"wifidetails switch update: {wifiDetails}")
         wifiStatus = await self._hass.async_add_executor_job(lambda: self._session.wifiStatus(internetProductIdentifier, modemMac))
         _LOGGER.debug(f"wifiStatus switch handle: {wifiStatus}")
         wifiEnabled = wifiStatus.get('cos') == 'WSO_SHARING'
@@ -185,23 +147,17 @@ class ComponentSwitch():
 
     async def update(self):
         if self._update_required:
-            # no throttle if update is required
             await self.force_update()
         else:
             await self._update()
 
     async def turn_on_wifi(self):
-        # response = await self.handle_switch_wireless(True, None)
-        # return response.get("wifiEnabled")
         await self.handle_switch_wireless(True)
     
     async def turn_off_wifi(self):
-        # response = await self.handle_switch_wireless(False, None)
-        # return response.get("wifiEnabled")
         await self.handle_switch_wireless(False)
 
 class WifiSwitch(SwitchEntity):
-    """Representation of a Audi switch."""
     def __init__(self, data):
         self._data = data
 
@@ -211,19 +167,16 @@ class WifiSwitch(SwitchEntity):
     
     @property
     def icon(self) -> str:
-        """Shows the correct icon for container."""
         return "mdi:wifi-lock"
         
     @property
     def unique_id(self) -> str:
-        """Return the name of the sensor."""
         return (
             f"{NAME} Wifi {self._data._identifier}"
         )
     
     @property
     def device_info(self) -> dict:
-        """Return the device info."""
         return {
             "identifiers": {(NAME, self._data.unique_id)},
             "name": self._data.name,
@@ -235,13 +188,10 @@ class WifiSwitch(SwitchEntity):
     
     @property
     def is_on(self):
-        """Return true if switch is on."""
         return self._data._wifiState
     
     async def async_turn_on(self, **kwargs):
-        """Turn the switch on."""
         await self._data.turn_on_wifi()
 
     async def async_turn_off(self, **kwargs):
-        """Turn the switch off."""
         await self._data.turn_off_wifi()

--- a/custom_components/telenet_telemeter/translations/en.json
+++ b/custom_components/telenet_telemeter/translations/en.json
@@ -1,30 +1,31 @@
 {
     "config": {
-        "title": "Telenet Telemeter",
+        "title": "Telenet / BASE Telemeter",
         "step": {
             "user": {
-                "description": "Setup a Telenet Telementer sensor, username and password are required. Please indicate if internet and/or mobile usage is to be tracked.",
+                "description": "Setup a Telenet or BASE Telemeter sensor. Select your provider, enter your username and password, and indicate if internet and/or mobile usage is to be tracked.",
                 "data": {
+                    "provider": "Provider",
                     "username": "Email",
                     "password": "Password",
-					"internet": "Internet",
-					"mobile": "Mobile"
+                    "internet": "Internet",
+                    "mobile": "Mobile"
                 }
             },
             "edit": {
-                "description": "Edit Setup a Telenet Telemeter sensor, username and password are required. Please indicate if internet and/or mobile usage is to be tracked.",
+                "description": "Edit Telenet or BASE Telemeter sensor setup.",
                 "data": {
+                    "provider": "Provider",
                     "username": "Email",
                     "password": "Password",
-					"internet": "Internet",
-					"mobile": "Mobile"
+                    "internet": "Internet",
+                    "mobile": "Mobile"
                 }
             }
-
         },
         "error": {
-            "missing username": "Please provide a valid Telenet username (email)",
-            "missing password": "Please provide a valid Telenet password",
+            "missing username": "Please provide a valid username (email)",
+            "missing password": "Please provide a valid password",
             "missing internet": "Please indicate if internet usage is to be tracked",
             "missing mobile": "Please indicate if mobile usage is to be tracked",
             "missing data options handler": "Option handler failed",
@@ -34,18 +35,19 @@
     "options": {
         "step": {
             "edit": {
-                "description": "Edit setup a Telenet Telemeter sensor, username and password are required. Please indicate if internet and/or mobile usage is to be tracked.",
+                "description": "Edit Telenet or BASE Telemeter sensor setup.",
                 "data": {
+                    "provider": "Provider",
                     "username": "Email",
                     "password": "Password",
-					"internet": "Internet",
-					"mobile": "Mobile"
+                    "internet": "Internet",
+                    "mobile": "Mobile"
                 }
             }
         },
         "error": {
-            "missing username": "Please provide a valid Telenet username (Email)",
-            "missing password": "Please provide a valid Telenet password",
+            "missing username": "Please provide a valid username (email)",
+            "missing password": "Please provide a valid password",
             "missing internet": "Please indicate if internet usage is to be tracked",
             "missing mobile": "Please indicate if mobile usage is to be tracked",
             "missing data options handler": "Option handler failed",

--- a/custom_components/telenet_telemeter/translations/fr.json
+++ b/custom_components/telenet_telemeter/translations/fr.json
@@ -1,10 +1,11 @@
 {
     "config": {
-        "title": "Telenet Telemeter",
+        "title": "Telenet / BASE Telemeter",
         "step": {
             "user": {
-                "description": "Configurer un capteur Telenet Telemeter, nom d'utilisateur et mot de passe requis. Veuillez indiquer si l'utilisation d'internet et/ou de mobile doit être suivie.",
+                "description": "Configurez un capteur Telenet ou BASE Telemeter. Choisissez votre fournisseur, entrez votre nom d'utilisateur et mot de passe, et indiquez si l'utilisation d'internet et/ou de mobile doit être suivie.",
                 "data": {
+                    "provider": "Fournisseur",
                     "username": "E-mail",
                     "password": "Mot de passe",
                     "internet": "Internet",
@@ -12,8 +13,9 @@
                 }
             },
             "edit": {
-                "description": "Modifier la configuration d'un capteur Telenet Telemeter, nom d'utilisateur et mot de passe requis. Veuillez indiquer si l'utilisation d'internet et/ou de mobile doit être suivie.",
+                "description": "Modifier la configuration du capteur Telenet ou BASE Telemeter.",
                 "data": {
+                    "provider": "Fournisseur",
                     "username": "E-mail",
                     "password": "Mot de passe",
                     "internet": "Internet",
@@ -22,8 +24,8 @@
             }
         },
         "error": {
-            "missing username": "Veuillez fournir un nom d'utilisateur Telenet valide (e-mail)",
-            "missing password": "Veuillez fournir un mot de passe Telenet valide",
+            "missing username": "Veuillez fournir un nom d'utilisateur valide (e-mail)",
+            "missing password": "Veuillez fournir un mot de passe valide",
             "missing internet": "Veuillez indiquer si l'utilisation d'internet doit être suivie",
             "missing mobile": "Veuillez indiquer si l'utilisation mobile doit être suivie",
             "missing data options handler": "Le gestionnaire d'options a échoué",
@@ -33,8 +35,9 @@
     "options": {
         "step": {
             "edit": {
-                "description": "Modifier la configuration d'un capteur Telenet Telemeter, nom d'utilisateur et mot de passe requis. Veuillez indiquer si l'utilisation d'internet et/ou de mobile doit être suivie.",
+                "description": "Modifier la configuration du capteur Telenet ou BASE Telemeter.",
                 "data": {
+                    "provider": "Fournisseur",
                     "username": "E-mail",
                     "password": "Mot de passe",
                     "internet": "Internet",
@@ -43,8 +46,8 @@
             }
         },
         "error": {
-            "missing username": "Veuillez fournir un nom d'utilisateur Telenet valide (e-mail)",
-            "missing password": "Veuillez fournir un mot de passe Telenet valide",
+            "missing username": "Veuillez fournir un nom d'utilisateur valide (e-mail)",
+            "missing password": "Veuillez fournir un mot de passe valide",
             "missing internet": "Veuillez indiquer si l'utilisation d'internet doit être suivie",
             "missing mobile": "Veuillez indiquer si l'utilisation mobile doit être suivie",
             "missing data options handler": "Le gestionnaire d'options a échoué",

--- a/custom_components/telenet_telemeter/translations/nl.json
+++ b/custom_components/telenet_telemeter/translations/nl.json
@@ -1,10 +1,11 @@
 {
     "config": {
-        "title": "Telenet Telemeter",
+        "title": "Telenet / BASE Telemeter",
         "step": {
             "user": {
-                "description": "Stel een Telenet Telemeter-sensor in, gebruikersnaam en wachtwoord zijn vereist. Geef aan of internet- en/of mobiel gebruik gevolgd moet worden.",
+                "description": "Stel een Telenet of BASE Telemeter-sensor in. Kies je provider, vul je gebruikersnaam en wachtwoord in, en geef aan of internet- en/of mobiel gebruik gevolgd moet worden.",
                 "data": {
+                    "provider": "Provider",
                     "username": "E-mail",
                     "password": "Wachtwoord",
                     "internet": "Internet",
@@ -12,8 +13,9 @@
                 }
             },
             "edit": {
-                "description": "Bewerk de instelling van een Telenet Telemeter-sensor, gebruikersnaam en wachtwoord zijn vereist. Geef aan of internet- en/of mobiel gebruik gevolgd moet worden.",
+                "description": "Bewerk de Telenet of BASE Telemeter-sensorinstelling.",
                 "data": {
+                    "provider": "Provider",
                     "username": "E-mail",
                     "password": "Wachtwoord",
                     "internet": "Internet",
@@ -22,8 +24,8 @@
             }
         },
         "error": {
-            "missing username": "Geef een geldige Telenet-gebruikersnaam (e-mail) op",
-            "missing password": "Geef een geldig Telenet-wachtwoord op",
+            "missing username": "Geef een geldige gebruikersnaam (e-mail) op",
+            "missing password": "Geef een geldig wachtwoord op",
             "missing internet": "Geef aan of internetgebruik gevolgd moet worden",
             "missing mobile": "Geef aan of mobiel gebruik gevolgd moet worden",
             "missing data options handler": "Optie-handler is mislukt",
@@ -33,8 +35,9 @@
     "options": {
         "step": {
             "edit": {
-                "description": "Bewerk de instelling van een Telenet Telemeter-sensor, gebruikersnaam en wachtwoord zijn vereist. Geef aan of internet- en/of mobiel gebruik gevolgd moet worden.",
+                "description": "Bewerk de Telenet of BASE Telemeter-sensorinstelling.",
                 "data": {
+                    "provider": "Provider",
                     "username": "E-mail",
                     "password": "Wachtwoord",
                     "internet": "Internet",
@@ -43,8 +46,8 @@
             }
         },
         "error": {
-            "missing username": "Geef een geldige Telenet-gebruikersnaam (e-mail) op",
-            "missing password": "Geef een geldig Telenet-wachtwoord op",
+            "missing username": "Geef een geldige gebruikersnaam (e-mail) op",
+            "missing password": "Geef een geldig wachtwoord op",
             "missing internet": "Geef aan of internetgebruik gevolgd moet worden",
             "missing mobile": "Geef aan of mobiel gebruik gevolgd moet worden",
             "missing data options handler": "Optie-handler is mislukt",

--- a/custom_components/telenet_telemeter/translations/sk.json
+++ b/custom_components/telenet_telemeter/translations/sk.json
@@ -56,8 +56,8 @@
     },
     "services": {
         "reboot_internet": {
-            "name": "reboot_internet",
-            "description": "Reboot the internet modem"
+            "name": "reštartovať_internet",
+            "description": "Reštartujte internetový modem"
         }
     }
 }

--- a/custom_components/telenet_telemeter/translations/sk.json
+++ b/custom_components/telenet_telemeter/translations/sk.json
@@ -1,30 +1,31 @@
 {
     "config": {
-        "title": "Telenet Telemeter",
+        "title": "Telenet / BASE Telemeter",
         "step": {
             "user": {
-                "description": "Vyžaduje sa nastavenie snímača Telenet Telementer, používateľské meno a heslo. Uveďte, či sa má sledovať používanie internetu a/alebo mobilu.",
+                "description": "Nastavte snímač Telenet alebo BASE Telemeter. Vyberte svojho poskytovateľa, zadajte používateľské meno a heslo a uveďte, či sa má sledovať používanie internetu a/alebo mobilu.",
                 "data": {
+                    "provider": "Poskytovateľ",
                     "username": "Používateľské meno",
                     "password": "Heslo",
-					"internet": "Internet",
-					"mobile": "Mobil"
+                    "internet": "Internet",
+                    "mobile": "Mobil"
                 }
             },
             "edit": {
-                "description": "Upraviť nastavenie Vyžaduje sa snímač telenetového telemetra, používateľské meno a heslo. Uveďte, či sa má sledovať používanie internetu a/alebo mobilu.",
+                "description": "Upraviť nastavenie snímača Telenet alebo BASE Telemeter.",
                 "data": {
+                    "provider": "Poskytovateľ",
                     "username": "Používateľské meno",
                     "password": "Heslo",
-					"internet": "Internet",
-					"mobile": "Mobil"
+                    "internet": "Internet",
+                    "mobile": "Mobil"
                 }
             }
-
         },
         "error": {
-            "missing username": "Zadajte platné používateľské meno služby Telenet",
-            "missing password": "Zadajte platné heslo služby Telenet",
+            "missing username": "Zadajte platné používateľské meno",
+            "missing password": "Zadajte platné heslo",
             "missing internet": "Uveďte, či sa má sledovať používanie internetu",
             "missing mobile": "Uveďte, či sa má sledovať používanie mobilných zariadení",
             "missing data options handler": "Obslužný program možností zlyhal",
@@ -34,18 +35,19 @@
     "options": {
         "step": {
             "edit": {
-                "description": "Upraviť nastavenie Vyžaduje sa snímač telenetového telemetra, používateľské meno a heslo. Uveďte, či sa má sledovať používanie internetu a/alebo mobilu.",
+                "description": "Upraviť nastavenie snímača Telenet alebo BASE Telemeter.",
                 "data": {
+                    "provider": "Poskytovateľ",
                     "username": "Používateľské meno",
                     "password": "Heslo",
-					"internet": "Internet",
-					"mobile": "Mobil"
+                    "internet": "Internet",
+                    "mobile": "Mobil"
                 }
             }
         },
         "error": {
-            "missing username": "Zadajte platné používateľské meno služby Telenet",
-            "missing password": "Zadajte platné heslo služby Telenet",
+            "missing username": "Zadajte platné používateľské meno",
+            "missing password": "Zadajte platné heslo",
             "missing internet": "Uveďte, či sa má sledovať používanie internetu",
             "missing mobile": "Uveďte, či sa má sledovať používanie mobilných zariadení",
             "missing data options handler": "Obslužný program možností zlyhal",

--- a/custom_components/telenet_telemeter/utils.py
+++ b/custom_components/telenet_telemeter/utils.py
@@ -13,11 +13,10 @@ from ratelimit import limits, sleep_and_retry
 
 import voluptuous as vol
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from .const import (
-    DOMAIN,
-)
 
-_LOGGER = logging.getLogger(DOMAIN)
+from .const import PROVIDER_TELENET, PROVIDER_BASE, PROVIDER_CONFIG
+
+_LOGGER = logging.getLogger(__name__)
 
 TELENET_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.0%z"
 
@@ -57,13 +56,18 @@ class HttpMethod(Enum):
     
 
 class TelenetSession(object):
-    def __init__(self):
+    def __init__(self, provider=PROVIDER_TELENET):
+        self.provider = provider
+        self.cfg = PROVIDER_CONFIG.get(provider, PROVIDER_CONFIG[PROVIDER_TELENET])
+        self.api_url = self.cfg["api_url"]
+        self.secure_url = self.cfg["secure_url"]
+
         self.s = requests.Session()
         self.s.headers["User-Agent"] = "Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0"
-        self.s.headers["x-alt-referer"] = "https://www2.telenet.be/residential/nl/mijn-telenet/"
+        self.s.headers["x-alt-referer"] = self.cfg["alt_referer"]
         self.s.headers["X-Requested-With"] = "XMLHttpRequest"
-        self.s.headers["Origin"] = "https://www2.telenet.be"
-        self.s.headers["Referrer"] = "https://www2.telenet.be"
+        self.s.headers["Origin"] = self.cfg["origin"]
+        self.s.headers["Referrer"] = self.cfg["referrer"]
 
     def callTelenet(self, url, caller = "Not set", expectedStatusCode = 200, data = None, printResponse = False, method : HttpMethod  = HttpMethod.GET, allowRedirects = True):
         try:
@@ -95,40 +99,34 @@ class TelenetSession(object):
     @sleep_and_retry
     @limits(calls=1, period=5)
     def login(self, username, password):
-        _LOGGER.info("Trying to login to My Telenet")
-        assert not self.callTelenet(url="https://api.prd.telenet.be/omapi/public/publicconfigs/maintenance_ocapi", caller="login").json()["enabled"]
+        _LOGGER.info(f"Trying to login to My {self.provider}")
 
-        response = self.callTelenet(url="https://api.prd.telenet.be/ocapi/oauth/userdetails", caller="login", expectedStatusCode=None)
+        # Check maintenance — skip for BASE if endpoint doesn't exist
+        try:
+            maintenance = self.callTelenet(url=self.cfg["maintenance_url"], caller="login").json()
+            assert not maintenance["enabled"]
+        except Exception:
+            _LOGGER.debug(f"[login] Maintenance check skipped or failed for {self.provider}")
+
+        response = self.callTelenet(url=f"{self.api_url}/ocapi/oauth/userdetails", caller="login", expectedStatusCode=None)
         if response.status_code == 200:
             # Return if already authenticated
             return
         assert response.status_code == 401
-        # Fetch state & nonce
-        _LOGGER.debug(f"Loging response to split state, nonce: {response.text} - ({response.status_code}) - {response.headers}")
+        _LOGGER.debug(f"Login response to split state, nonce: {response.text} - ({response.status_code}) - {response.headers}")
         state, nonce = response.text.split(",", maxsplit=2)
 
         # Fetch the initial state token
+        # BASE returns 200 directly (follows redirect internally), Telenet returns 302
         state_token_response = self.callTelenet(
-            url="https://api.prd.telenet.be/ocapi/login/authorization/telenet_be?lang=nl&style_hint=care&targetUrl=https://www2.telenet.be/residential/nl/mytelenet/",
+            url=self.cfg["authorization_url"],
             caller="login",
-            expectedStatusCode=302,
+            expectedStatusCode=None,
             allowRedirects=True
         )
-        _LOGGER.debug(f"State token response:  ({state_token_response.status_code}) - {state_token_response.headers}")
-
-        # If allowRedirects=False, the follow up request needs to be manually executed based on location of response header
-        # #get location url out of response header
-        # authorizeUrl = state_token_response.headers.get("location")
-        # _LOGGER.debug(f"authorizeUrl: {authorizeUrl}")
-        
-
-        # #  https://secure.telenet.be/oauth2/default/v1/authorize?client_id=***********&response_type=code&redirect_uri=https://api.prd.telenet.be/ocapi/login/callback/telenet_be&state=*************&nonce=*******&scope=openid%20profile%20licenses%20telenet.scopes%20offline_access&claims=%7B%22id_token%22:%7B%22http://telenet.be/claims/roles%22:null%7D%7D&code_challenge=**********&code_challenge_method=S256
-        # state_token_response = self.callTelenet(
-        #     # url="https://api.prd.telenet.be/ocapi/login/authorization/telenet_be?client_id=telenet_be&response_type=code&claims={\"id_token\":{\"http://telenet.be/claims/roles\":null,\"http://telenet.be/claims/licenses\":null}}&lang=nl&nonce=" + nonce + "&state=" + state + "&prompt=none",
-        #     url=authorizeUrl,
-        #     caller="login"
-        # )
-        
+        _LOGGER.debug(f"Authorization URL status: {state_token_response.status_code}")
+        assert state_token_response.status_code in [200, 302], f"Unexpected status {state_token_response.status_code}"
+        _LOGGER.debug(f"State token response: ({state_token_response.status_code}) - {state_token_response.headers}")
 
         state_token_matcher = re.search('"stateToken":"(.*)","helpLinks"', state_token_response.text) 
         state_token_encoded = state_token_matcher.group(1)
@@ -136,24 +134,23 @@ class TelenetSession(object):
         _LOGGER.debug(f"Initial state token {state_token_decoded}")
         
         introspection_response = self.callTelenet(
-            url="https://secure.telenet.be/idp/idx/introspect",
+            url=f"{self.secure_url}/idp/idx/introspect",
             method=HttpMethod.POST,
             data=json.dumps({"stateToken": state_token_decoded}),
             caller="login"
         )
         state_handle = introspection_response.json()['stateHandle']
 
-        self.callTelenet(url="https://secure.telenet.be/auth/services/devicefingerprint", caller="login")
-        self.callTelenet(url="https://secure.telenet.be/api/v1/internal/device/nonce", method=HttpMethod.POST, caller="login")
+        self.callTelenet(url=f"{self.secure_url}/auth/services/devicefingerprint", caller="login")
+        self.callTelenet(url=f"{self.secure_url}/api/v1/internal/device/nonce", method=HttpMethod.POST, caller="login")
         identify_response = self.callTelenet(
-            url="https://secure.telenet.be/idp/idx/identify", 
+            url=f"{self.secure_url}/idp/idx/identify", 
             data=json.dumps({'identifier': username, 'stateHandle': state_handle}),
             method=HttpMethod.POST,
             caller="login"
         )
         state_handle = identify_response.json()['stateHandle']
-        # authenticator = identify_response.json()['authenticators']['value'][0]['id']
-        # fetch the authenticator id linked to password login, this isn't always the first
+
         password_id = None
         for auth in identify_response.json()["authenticators"]["value"]:
             if auth.get("type") == "password":
@@ -161,13 +158,13 @@ class TelenetSession(object):
                 break
 
         challenge_response = self.callTelenet(
-            url="https://secure.telenet.be/idp/idx/challenge",
+            url=f"{self.secure_url}/idp/idx/challenge",
             data=json.dumps({
                 "authenticator":
                     {
-                        "id":password_id
+                        "id": password_id
                     },
-                    "stateHandle":state_handle
+                    "stateHandle": state_handle
                 }
             ),
             method=HttpMethod.POST,
@@ -176,13 +173,13 @@ class TelenetSession(object):
         state_handle = challenge_response.json()['stateHandle']
 
         answer_response = self.callTelenet(
-            url="https://secure.telenet.be/idp/idx/challenge/answer",
+            url=f"{self.secure_url}/idp/idx/challenge/answer",
             data=json.dumps({
                 "credentials":
                     {
-                        "passcode":password
+                        "passcode": password
                     },
-                    "stateHandle":state_handle
+                    "stateHandle": state_handle
                 }
             ),
             method=HttpMethod.POST,
@@ -194,93 +191,90 @@ class TelenetSession(object):
 
 
     def userdetails(self):
-        response = self.callTelenet("https://api.prd.telenet.be/ocapi/oauth/userdetails","userdetails", None)
+        response = self.callTelenet(f"{self.api_url}/ocapi/oauth/userdetails", "userdetails", None)
         return response.json()
     
     def customerdetails(self):
-        response = self.callTelenet("https://api.prd.telenet.be/ocapi/public/api/customer-service/v1/customers","customerdetails")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/customer-service/v1/customers", "customerdetails")
         return response.json()
 
     def telemeter(self):
-        response = self.callTelenet("https://api.prd.telenet.be/ocapi/public/?p=internetusage,internetusagereminder","telemeter")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/?p=internetusage,internetusagereminder", "telemeter")
         return response.json()
 
     def telemeter_product_details(self, url):
-        response = self.callTelenet(url,"telemeter_product_details")
+        response = self.callTelenet(url, "telemeter_product_details")
         return response.json()
 
     def modemdetails(self, productIdentifier):
-        response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/resource-service/v1/modems?productIdentifier={productIdentifier}","modemdetails")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/resource-service/v1/modems?productIdentifier={productIdentifier}", "modemdetails")
         return response.json()
     
     def wifidetails(self, productIdentifier, modemMac):
-        response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/resource-service/v1/modems/{modemMac}/wireless-settings?withmetadata=true&withwirelessservice=true&productidentifier={productIdentifier}","wifidetails")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/resource-service/v1/modems/{modemMac}/wireless-settings?withmetadata=true&withwirelessservice=true&productidentifier={productIdentifier}", "wifidetails")
         return response.json()
     
     def wifiStatus(self, productIdentifier, modemMac):
-        response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/resource-service/v1/modems/{modemMac}/wireless-status?productidentifier={productIdentifier}","wifiStatus")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/resource-service/v1/modems/{modemMac}/wireless-status?productidentifier={productIdentifier}", "wifiStatus")
         return response.json()
     
     def urldetails(self, url):
-        response = self.callTelenet(url,"urldetails")
+        response = self.callTelenet(url, "urldetails")
         return response.json()
     
-    def switchWifi(self,  wirelessEnabled: bool, productIdentifier: bool, modemMac, locationId):
-        # data = {"productIdentifier":productIdentifier,"homeSpotEnabled":homeSpotEnabled,"wirelessEnabled":"Yes","locationId":locationId,"patchOperations":[{"op":"replace","path":"/wirelessInterfaces/2.4GHZ/ssids/PRIMARY/active","value":wirelessEnabled},{"op":"replace","path":"/wirelessInterfaces/5GHZ/ssids/PRIMARY/active","value":wirelessEnabled}]}
+    def switchWifi(self, wirelessEnabled: bool, productIdentifier: bool, modemMac, locationId):
         if wirelessEnabled:
             data = {"cos": "WSO_SHARING"}
         else:
-            data = {"cos":"WSO_OFF"}
-        # self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/resource-service/v1/modems/{modemMac}/wireless-settings","optionswifi", 200, None, True, HttpMethod.OPTIONS)
-        # self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/resource-service/v1/modems/{modemMac}/wireless-settings","patchwifi", 200, data, True, HttpMethod.PATCH)
-        self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/resource-service/v1/modems/{modemMac}/wireless-status","patchwifi", 200, data, True, HttpMethod.PATCH)
+            data = {"cos": "WSO_OFF"}
+        self.callTelenet(f"{self.api_url}/ocapi/public/api/resource-service/v1/modems/{modemMac}/wireless-status", "patchwifi", 200, data, True, HttpMethod.PATCH)
         return
     
     def reboot(self, modemMac):
-        self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/resource-service/v1/modems/{modemMac}/reboot","modem_general reboot", 200, None, True, HttpMethod.POST)
+        self.callTelenet(f"{self.api_url}/ocapi/public/api/resource-service/v1/modems/{modemMac}/reboot", "modem_general reboot", 200, None, True, HttpMethod.POST)
         return
     
     def mobile(self):
-        response = self.callTelenet("https://api.prd.telenet.be/ocapi/public/?p=mobileusage","mobile")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/?p=mobileusage", "mobile")
         return response.json()
         
     def planInfo(self):
-        response = self.callTelenet("https://api.prd.telenet.be/ocapi/public/api/product-service/v1/product-subscriptions?producttypes=PLAN","planInfo")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/product-service/v1/product-subscriptions?producttypes=PLAN", "planInfo")
         return response.json()
     
     def billCycles(self, productType, productIdentifier):
-        response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/billing-service/v1/account/products/{productIdentifier}/billcycle-details?producttype={productType}&count=3","billCycles")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/billing-service/v1/account/products/{productIdentifier}/billcycle-details?producttype={productType}&count=3", "billCycles")
         return response.json()
     
-    def productUsage(self, productType, productIdentifier,startDate, endDate):
-        response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/product-service/v1/products/{productType}/{productIdentifier}/usage?fromDate={startDate}&toDate={endDate}","productUsage")
+    def productUsage(self, productType, productIdentifier, startDate, endDate):
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/product-service/v1/products/{productType}/{productIdentifier}/usage?fromDate={startDate}&toDate={endDate}", "productUsage")
         return response.json()
     
-    def productDailyUsage(self, productType, productIdentifier,startDate, endDate):
-        response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/product-service/v1/products/{productType}/{productIdentifier}/dailyusage?billcycle=CURRENT&fromDate={startDate}&toDate={endDate}","productUsage")
+    def productDailyUsage(self, productType, productIdentifier, startDate, endDate):
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/product-service/v1/products/{productType}/{productIdentifier}/dailyusage?billcycle=CURRENT&fromDate={startDate}&toDate={endDate}", "productUsage")
         return response.json()
 
     def productSubscriptions(self, productType):
-        response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/product-service/v1/product-subscriptions?producttypes={productType}","productSubscriptions")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/product-service/v1/product-subscriptions?producttypes={productType}", "productSubscriptions")
         return response.json()
 
     def productService(self, productIdentifier, productType):
-        response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/product-service/v1/products/{productIdentifier}?producttype={productType.lower()}","productService")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/product-service/v1/products/{productIdentifier}?producttype={productType.lower()}", "productService")
         return response.json()
 
     def mobileUsage(self, productIdentifier):
-        response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/mobile-service/v3/mobilesubscriptions/{productIdentifier}/usages","mobileUsage")
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/mobile-service/v3/mobilesubscriptions/{productIdentifier}/usages", "mobileUsage")
         return response.json()
 
-    def mobileBundleUsage(self, bundleIdentifier, lineIdentifier = None):
-        if lineIdentifier != None:
-            response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/mobile-service/v3/mobilesubscriptions/{bundleIdentifier}/usages?type=bundle&lineIdentifier={lineIdentifier}","mobileBundleUsage lineIdentifier")
+    def mobileBundleUsage(self, bundleIdentifier, lineIdentifier=None):
+        if lineIdentifier is not None:
+            response = self.callTelenet(f"{self.api_url}/ocapi/public/api/mobile-service/v3/mobilesubscriptions/{bundleIdentifier}/usages?type=bundle&lineIdentifier={lineIdentifier}", "mobileBundleUsage lineIdentifier")
         else:
-            response = self.callTelenet(f"https://api.prd.telenet.be/ocapi/public/api/mobile-service/v3/mobilesubscriptions/{bundleIdentifier}/usages?type=bundle","mobileBundleUsage bundle")
+            response = self.callTelenet(f"{self.api_url}/ocapi/public/api/mobile-service/v3/mobilesubscriptions/{bundleIdentifier}/usages?type=bundle", "mobileBundleUsage bundle")
         return response.json()
 
     def apiVersion2(self):
-        response = self.callTelenet("https://api.prd.telenet.be/ocapi/public/api/product-service/v1/product-subscriptions?producttypes=PLAN","apiVersion2", None)
+        response = self.callTelenet(f"{self.api_url}/ocapi/public/api/product-service/v1/product-subscriptions?producttypes=PLAN", "apiVersion2", None)
         if response.status_code == 200:
             return True
         return False

--- a/custom_components/telenet_telemeter/utils.py
+++ b/custom_components/telenet_telemeter/utils.py
@@ -105,8 +105,10 @@ class TelenetSession(object):
         try:
             maintenance = self.callTelenet(url=self.cfg["maintenance_url"], caller="login").json()
             assert not maintenance["enabled"]
-        except Exception:
-            _LOGGER.debug(f"[login] Maintenance check skipped or failed for {self.provider}")
+        except (KeyError, AssertionError):
+            _LOGGER.debug(f"[login] Maintenance check skipped for {self.provider}")
+        except Exception as e:
+            _LOGGER.warning(f"[login] Maintenance check failed for {self.provider}: {e}")
 
         response = self.callTelenet(url=f"{self.api_url}/ocapi/oauth/userdetails", caller="login", expectedStatusCode=None)
         if response.status_code == 200:
@@ -114,7 +116,7 @@ class TelenetSession(object):
             return
         assert response.status_code == 401
         _LOGGER.debug(f"Login response to split state, nonce: {response.text} - ({response.status_code}) - {response.headers}")
-        state, nonce = response.text.split(",", maxsplit=2)
+        _state, _nonce = response.text.split(",", maxsplit=2)
 
         # Fetch the initial state token
         # BASE returns 200 directly (follows redirect internally), Telenet returns 302
@@ -160,13 +162,9 @@ class TelenetSession(object):
         challenge_response = self.callTelenet(
             url=f"{self.secure_url}/idp/idx/challenge",
             data=json.dumps({
-                "authenticator":
-                    {
-                        "id": password_id
-                    },
-                    "stateHandle": state_handle
-                }
-            ),
+                "authenticator": {"id": password_id},
+                "stateHandle": state_handle
+            }),
             method=HttpMethod.POST,
             caller="login"
         )
@@ -175,13 +173,9 @@ class TelenetSession(object):
         answer_response = self.callTelenet(
             url=f"{self.secure_url}/idp/idx/challenge/answer",
             data=json.dumps({
-                "credentials":
-                    {
-                        "passcode": password
-                    },
-                    "stateHandle": state_handle
-                }
-            ),
+                "credentials": {"passcode": password},
+                "stateHandle": state_handle
+            }),
             method=HttpMethod.POST,
             caller="login"
         )


### PR DESCRIPTION
## Summary
This PR adds support for BASE Belgium as a second provider alongside the existing Telenet integration. BASE is a subsidiary of Telenet and uses the same backend infrastructure but with different API endpoints and OAuth configuration.

> **Note:** This implementation was put together quickly based on reverse engineering the BASE API. It is functional and tested, but may still contain some rough edges — in particular, most naming and branding throughout the integration still refers to "Telenet" (sensor names, device names, attribution, etc.). Further refinement of naming conventions to be more provider-neutral is very welcome!

## Changes
- **Provider selection**: Added selection in config flow to choose between Telenet and BASE
- **API endpoints**: BASE uses `api.prd.base.be` and `secure.base.be`
- **OAuth login**: BASE uses `secure.base.be` with its own `client_id` and callback URL
- **Bug fix**: `offPeak` usage now defaults to 0 when not present (affects FUP subscriptions without off-peak hours)
- **Bug fix**: Monetary data bundles (BASE BoY plans where €1 = 1 GB) now correctly displayed as GB
- **Translations**: Provider field added to en/nl/fr/sk translations
- **Fix**: Provider passed correctly to TelenetSession in reboot_internet service

## Tested with
- BASE unlimited internet ✅
- BASE 15 mobile subscription ✅
- Existing Telenet setup unaffected ✅

## Notes
- The authorization URL returns HTTP 200 instead of 302 for BASE (redirect followed internally) — handled gracefully
- BASE BoY mobile plans store data as monetary units (€1 = 1 GB) — fallback converts to GB for display